### PR TITLE
fix: added validation for phoneNumber which runs only if it was given…

### DIFF
--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -56,6 +56,40 @@ const UserSchema = new Schema<IUser, UserModel, IUserMethods>(
     },
     phoneNumber: {
       type: String,
+      validate: [
+        {
+          validator: async function (
+            this: HydratedDocument<IUser>,
+            phoneNumber: string,
+          ): Promise<boolean> {
+            if (!phoneNumber) {
+              return true;
+            }
+
+            if (!this.isModified('phoneNumber')) {
+              return true;
+            }
+
+            const user = await User.findOne({
+              phoneNumber,
+            });
+
+            return !user;
+          },
+          message: 'Пользователь с таким номером телефона уже зарегистрирован!',
+        },
+        {
+          validator: function (phoneNumber: string): boolean {
+            if (!phoneNumber) {
+              return true;
+            }
+
+            const regex = /^\+996\d{9}$/;
+            return regex.test(phoneNumber);
+          },
+          message: 'Неверный формат номера телефона!',
+        },
+      ],
     },
     role: {
       type: String,


### PR DESCRIPTION
Added validation for phoneNumber on user registration. Validation works only if user provides the number it on registration, if the phoneNumber field was empty, validation does not run. 
Added validation on unique of numbers and format. 
Tested, works well, and doesn't conflict on Google authorization.